### PR TITLE
update most deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "overustle.com api server",
   "repository": "git@github.com:hayksaakian/OverRustle-API.git",
   "dependencies": {
-    "bluebird": "2.9.25",
-    "body-parser": "1.10.1",
-    "dotenv": "0.4.0",
-    "express": "4.10.2",
+    "bluebird": "^3.4.6",
+    "body-parser": "^1.10.1",
+    "dotenv": "^2.0.0",
+    "express": "^4.10.2",
     "has": "^1.0.1",
-    "jsonfile": "2.0.0",
-    "multer": "0.1.6",
-    "redis": "0.12.1",
-    "request": "2.49.0",
-    "socket.io": "1.2.0"
+    "jsonfile": "^2.0.0",
+    "multer": "^0.1.6",
+    "redis": "^2.6.3",
+    "request": "^2.49.0",
+    "socket.io": "^1.2.0"
   }
 }


### PR DESCRIPTION
This patch updates all deps to their latest versions (except `multer`, which will require a bit more work).

I tested this a bit locally and everything appears to be working fine but let me know if you find any issues.

Closes https://github.com/ILiedAboutCake/OverRustle-API/issues/23